### PR TITLE
Fix session routing: use claude_session_id instead of cwd-only matching

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1100,7 +1100,8 @@ func listen() error {
 
 				// /new <name> - create brand new session + topic
 				if arg != "" {
-					if _, exists := config.Sessions[arg]; exists {
+					existing, exists := config.Sessions[arg]
+					if exists && existing != nil && existing.TopicID != 0 {
 						sendMessage(config, chatID, threadID, fmt.Sprintf("⚠️ Session '%s' already exists. Use /new without args in that topic to restart.", arg))
 						continue
 					}
@@ -1109,7 +1110,11 @@ func listen() error {
 						sendMessage(config, chatID, threadID, fmt.Sprintf("❌ Failed to create topic: %v", err))
 						continue
 					}
+					// Use pre-configured path if session was preset, otherwise resolve from name
 					workDir := resolveProjectPath(config, arg)
+					if exists && existing != nil && existing.Path != "" {
+						workDir = existing.Path
+					}
 					config.Sessions[arg] = &SessionInfo{
 						TopicID: topicID,
 						Path:    workDir,

--- a/hooks.go
+++ b/hooks.go
@@ -501,6 +501,14 @@ func handleUserPromptHook() error {
 
 	persistClaudeSessionID(config, sessName, hookData.SessionID)
 
+	// Skip if this prompt came from Telegram (already visible in the chat)
+	tmuxName := "claude-" + strings.ReplaceAll(sessName, ".", "_")
+	if flagInfo, err := os.Stat(telegramActiveFlag(tmuxName)); err == nil {
+		if time.Since(flagInfo.ModTime()) < 5*time.Minute {
+			return nil
+		}
+	}
+
 	sendMessage(config, config.GroupID, topicID, fmt.Sprintf("💬 %s", hookData.Prompt))
 	return nil
 }

--- a/hooks.go
+++ b/hooks.go
@@ -34,8 +34,24 @@ func readHookStdin() ([]byte, error) {
 	}
 }
 
-// findSession matches a hook's cwd to a configured session
-func findSession(config *Config, cwd string) (string, int64) {
+// findSessionByClaudeID matches a claude session ID to a configured session
+func findSessionByClaudeID(config *Config, claudeSessionID string) (string, int64) {
+	if claudeSessionID == "" {
+		return "", 0
+	}
+	for name, info := range config.Sessions {
+		if name == "" || info == nil {
+			continue
+		}
+		if info.ClaudeSessionID == claudeSessionID {
+			return name, info.TopicID
+		}
+	}
+	return "", 0
+}
+
+// findSessionByCwd matches a hook's cwd to a configured session (fallback)
+func findSessionByCwd(config *Config, cwd string) (string, int64) {
 	for name, info := range config.Sessions {
 		if name == "" || info == nil {
 			continue
@@ -45,6 +61,30 @@ func findSession(config *Config, cwd string) (string, int64) {
 		}
 	}
 	return "", 0
+}
+
+// findSession matches by claude_session_id first, then falls back to cwd
+func findSession(config *Config, cwd string, claudeSessionID string) (string, int64) {
+	if name, topicID := findSessionByClaudeID(config, claudeSessionID); name != "" {
+		return name, topicID
+	}
+	return findSessionByCwd(config, cwd)
+}
+
+// persistClaudeSessionID saves the claude session ID to config if changed
+func persistClaudeSessionID(config *Config, sessName string, claudeSessionID string) {
+	if claudeSessionID == "" || sessName == "" {
+		return
+	}
+	info, exists := config.Sessions[sessName]
+	if !exists || info == nil {
+		return
+	}
+	if info.ClaudeSessionID != claudeSessionID {
+		info.ClaudeSessionID = claudeSessionID
+		saveConfig(config)
+		hookLog("persisted claude_session_id=%s for session=%s", claudeSessionID, sessName)
+	}
 }
 
 func handleStopHook() error {
@@ -65,28 +105,41 @@ func handleStopHook() error {
 		return nil
 	}
 
-	sessName, topicID := findSession(config, hookData.Cwd)
+	sessName, topicID := findSession(config, hookData.Cwd, hookData.SessionID)
 	if sessName == "" || config.GroupID == 0 || topicID == 0 {
 		return nil
 	}
 
-	hookLog("stop-hook: session=%s transcript=%s", sessName, hookData.TranscriptPath)
+	// Persist claude session ID to config for future lookups
+	persistClaudeSessionID(config, sessName, hookData.SessionID)
+
+	hookLog("stop-hook: session=%s claude_session_id=%s transcript=%s", sessName, hookData.SessionID, hookData.TranscriptPath)
 
 	// Clear Telegram active flag when Claude stops
 	tmuxName := "claude-" + strings.ReplaceAll(sessName, ".", "_")
 	os.Remove(telegramActiveFlag(tmuxName))
 
-	blocks := extractLastTurn(hookData.TranscriptPath)
+	// Retry extractLastTurn a few times - transcript may not be fully flushed yet
+	var blocks []string
+	for attempt := 0; attempt < 5; attempt++ {
+		blocks = extractLastTurn(hookData.TranscriptPath)
+		if len(blocks) > 0 {
+			break
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	hookLog("stop-hook: extractLastTurn returned %d blocks", len(blocks))
 	if len(blocks) == 0 {
 		// No text blocks found, just send completion marker
-		sendMessage(config, config.GroupID, topicID, fmt.Sprintf("✅ %s", sessName))
+		sendMessage(config, config.GroupID, topicID, fmt.Sprintf("*%s:* ✅", sessName))
 		return nil
 	}
 
 	for i, block := range blocks {
+		hookLog("stop-hook: block[%d] len=%d preview=%s", i, len(block), truncate(block, 80))
 		text := block
 		if i == len(blocks)-1 {
-			text = fmt.Sprintf("✅ %s\n\n%s", sessName, block)
+			text = fmt.Sprintf("*%s:*\n%s", sessName, block)
 		}
 		sendMessageGetID(config, config.GroupID, topicID, text)
 	}
@@ -277,10 +330,13 @@ func handlePermissionHook() error {
 		return nil
 	}
 
-	sessName, topicID := findSession(config, hookData.Cwd)
+	sessName, topicID := findSession(config, hookData.Cwd, hookData.SessionID)
 	if sessName == "" || config.GroupID == 0 {
 		return nil
 	}
+
+	// Persist claude session ID to config for future lookups
+	persistClaudeSessionID(config, sessName, hookData.SessionID)
 
 	// Handle AskUserQuestion - forward to Telegram with buttons
 	if hookData.ToolName == "AskUserQuestion" && len(hookData.ToolInput.Questions) > 0 {

--- a/hooks.go
+++ b/hooks.go
@@ -476,6 +476,35 @@ func outputPermissionDecision(decision, reason string) {
 	fmt.Println(string(data))
 }
 
+func handleUserPromptHook() error {
+	defer func() { recover() }()
+
+	rawData, _ := readHookStdin()
+	if len(rawData) == 0 {
+		return nil
+	}
+
+	hookData, err := parseHookData(rawData)
+	if err != nil || hookData.Prompt == "" {
+		return nil
+	}
+
+	config, err := loadConfig()
+	if err != nil || config == nil {
+		return nil
+	}
+
+	sessName, topicID := findSession(config, hookData.Cwd, hookData.SessionID)
+	if sessName == "" || config.GroupID == 0 || topicID == 0 {
+		return nil
+	}
+
+	persistClaudeSessionID(config, sessName, hookData.SessionID)
+
+	sendMessage(config, config.GroupID, topicID, fmt.Sprintf("💬 %s", hookData.Prompt))
+	return nil
+}
+
 func handleNotificationHook() error {
 	return nil
 }
@@ -548,6 +577,16 @@ func installHook() error {
 				"hooks": []interface{}{
 					map[string]interface{}{
 						"command": cccPath + " hook-stop",
+						"type":    "command",
+					},
+				},
+			},
+		},
+		"UserPromptSubmit": {
+			map[string]interface{}{
+				"hooks": []interface{}{
+					map[string]interface{}{
+						"command": cccPath + " hook-user-prompt",
 						"type":    "command",
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -346,6 +346,12 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "hook-user-prompt":
+		if err := handleUserPromptHook(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
 	case "hook-notification":
 		if err := handleNotificationHook(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const version = "1.6.2"
+const version = "1.7.0"
 
 // SessionInfo stores information about a session
 type SessionInfo struct {

--- a/telegram.go
+++ b/telegram.go
@@ -165,8 +165,9 @@ func sendMessageGetID(config *Config, chatID int64, threadID int64, text string)
 
 	for _, msg := range messages {
 		params := url.Values{
-			"chat_id": {fmt.Sprintf("%d", chatID)},
-			"text":    {msg},
+			"chat_id":    {fmt.Sprintf("%d", chatID)},
+			"text":       {msg},
+			"parse_mode": {"Markdown"},
 		}
 		if threadID > 0 {
 			params.Set("message_thread_id", fmt.Sprintf("%d", threadID))

--- a/tmux.go
+++ b/tmux.go
@@ -174,37 +174,14 @@ func sendToTmuxWithDelay(session string, text string, delay time.Duration) error
 		return err
 	}
 
-	// Wait for content to load (e.g., images)
-	time.Sleep(delay)
+	// Brief pause for TUI to process pasted text
+	time.Sleep(100 * time.Millisecond)
 
-	// Wait for "↵ send" indicator to appear (Claude Code is ready for Enter)
-	// Poll for up to 5 seconds
-	for i := 0; i < 50; i++ {
-		out, err := exec.Command(tmuxPath, "capture-pane", "-t", session, "-p", "-S", "-3").Output()
-		if err == nil && strings.Contains(string(out), "↵ send") {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
+	// Send Enter twice (Claude Code needs double Enter)
+	exec.Command(tmuxPath, "send-keys", "-t", session, "C-m").Run()
+	time.Sleep(50 * time.Millisecond)
+	exec.Command(tmuxPath, "send-keys", "-t", session, "C-m").Run()
 
-	// Try sending Enter up to 3 times, checking if it was processed
-	for attempt := 0; attempt < 3; attempt++ {
-		// Send Enter twice (Claude Code needs double Enter)
-		exec.Command(tmuxPath, "send-keys", "-t", session, "C-m").Run()
-		time.Sleep(50 * time.Millisecond)
-		exec.Command(tmuxPath, "send-keys", "-t", session, "C-m").Run()
-
-		// Wait a bit and check if "↵ send" is gone (meaning Enter was processed)
-		time.Sleep(300 * time.Millisecond)
-		out, err := exec.Command(tmuxPath, "capture-pane", "-t", session, "-p", "-S", "-3").Output()
-		if err != nil || !strings.Contains(string(out), "↵ send") {
-			// Either error or indicator gone - Enter was processed
-			return nil
-		}
-		hookLog("sendToTmux: attempt %d - Enter not processed, retrying", attempt+1)
-	}
-
-	hookLog("sendToTmux: Enter still not processed after 3 attempts")
 	return nil
 }
 


### PR DESCRIPTION
## Problem

On desktop (terminal), you can run multiple Claude Code sessions in the **same working directory** — each gets its own tmux session and a unique `session_id`. However, on mobile (Telegram), ccc routes hook events to topics using only `cwd`. Since Go map iteration is unordered, when two sessions share the same `cwd`, messages randomly go to whichever session matches first. This means Telegram receives a mixed stream of responses from different desktop sessions.

The `ClaudeSessionID` field already exists in the `SessionInfo` struct but is **never populated or used for matching**.

## Solution

### Session routing by `claude_session_id` (hooks.go)
- Add `findSessionByClaudeID()` — matches hook events to sessions using the unique Claude session ID
- Refactor `findSession(config, cwd, claudeSessionID)` to try `claude_session_id` first, fall back to `cwd`
- Add `persistClaudeSessionID()` — saves the session ID to config on each hook trigger (both Stop and Permission hooks), so the mapping builds up automatically
- Add retry logic for `extractLastTurn()` (5 attempts × 300ms) — fixes a race condition where the transcript file isn't fully flushed when the Stop hook fires

### Forward TUI user prompts to Telegram (NEW)
- Add `UserPromptSubmit` hook — when users type in the Claude Code TUI, their messages are synced to the corresponding Telegram topic with a `💬` prefix
- This provides complete conversation context in Telegram (both user messages and Claude responses), not just Claude's replies
- No deduplication needed: `UserPromptSubmit` only fires for TUI input, not for messages pasted via `sendToTmux` from Telegram

### Faster message delivery (tmux.go)
- Remove the `capture-pane` polling loop that waited up to 5 seconds for the "↵ send" indicator
- Replace with a simple 100ms pause + double Enter — eliminates 1-5 second delay per message

### Telegram formatting (telegram.go)
- Add `parse_mode: "Markdown"` to `sendMessage` — enables bold/italic formatting in messages
- Change message prefix from `✅ sessionName` to `*sessionName:*` — bold session name, avoids `@name` which Telegram renders as a clickable username link

### Pre-configured sessions (commands.go)
- Allow `/new <name>` when a session with `topic_id: 0` already exists in config — enables pre-setting session paths in the config file before creating the Telegram topic
- Use pre-configured `path` from existing config instead of auto-resolving from name

### Version
- 1.6.2 → 1.7.0

## Test plan
- [x] Create two sessions pointing to the same directory
- [x] Send messages from both — verify each routes to the correct Telegram topic
- [x] Restart ccc — verify persisted `claude_session_id` survives restart
- [x] Test `/new` with a pre-configured session (topic_id=0)
- [ ] Type in TUI — verify `💬 message` appears in the Telegram topic
- [ ] Send from Telegram — verify no duplicate `💬` message appears